### PR TITLE
Feature addition: Encoding option to CreateMemoryInArchive task

### DIFF
--- a/Frends.Community.Zip.Tests/Frends.Community.Zip.InMemoryTests.cs
+++ b/Frends.Community.Zip.Tests/Frends.Community.Zip.InMemoryTests.cs
@@ -43,17 +43,17 @@ namespace Frends.Community.Zip.InMemoryTests
                         new MemoryFiles
                         {
                             FileName = "test1.txt",
-                            FileContent = Encoding.UTF8.GetBytes(mockFiles[0])
+                            FileContent = System.Text.Encoding.UTF8.GetBytes(mockFiles[0])
                         },
                         new MemoryFiles
                         {
                             FileName = $"folder{Path.DirectorySeparatorChar}test2.txt",
-                            FileContent = Encoding.UTF8.GetBytes(mockFiles[1])
+                            FileContent = System.Text.Encoding.UTF8.GetBytes(mockFiles[1])
                         },
                         new MemoryFiles
                         {
                             FileName = "test3_äöå.txt",
-                            FileContent = Encoding.UTF8.GetBytes(mockFiles[2])
+                            FileContent = System.Text.Encoding.UTF8.GetBytes(mockFiles[2])
                         }
                     }
             };
@@ -62,7 +62,7 @@ namespace Frends.Community.Zip.InMemoryTests
 
             testEncodingOptions = new MemoryOptions()
             {
-                FileEncoding = FileEncoding.UTF8
+                Encoding = Encoding.UTF8
             };
 
             Directory.CreateDirectory(_basePath);
@@ -116,13 +116,13 @@ namespace Frends.Community.Zip.InMemoryTests
             ZipTask.ExtractArchive(unzipInput, unzipOptions, CancellationToken.None);
 
             Assert.True(File.Exists(Path.Combine(_outPath, "test1.txt")));
-            Assert.True(File.ReadAllText(Path.Combine(_outPath, "test1.txt"), Encoding.UTF8) == mockFiles[0]);
+            Assert.True(File.ReadAllText(Path.Combine(_outPath, "test1.txt"), System.Text.Encoding.UTF8) == mockFiles[0]);
 
             Assert.True(File.Exists(Path.Combine(_outPath, $"folder{Path.DirectorySeparatorChar}test2.txt")));
-            Assert.True(File.ReadAllText(Path.Combine(_outPath, $"folder{Path.DirectorySeparatorChar}test2.txt"), Encoding.UTF8) == mockFiles[1]);
+            Assert.True(File.ReadAllText(Path.Combine(_outPath, $"folder{Path.DirectorySeparatorChar}test2.txt"), System.Text.Encoding.UTF8) == mockFiles[1]);
 
             Assert.True(File.Exists(Path.Combine(_outPath, "test3_äöå.txt")));
-            Assert.True(File.ReadAllText(Path.Combine(_outPath, "test3_äöå.txt"), Encoding.UTF8) == mockFiles[2]);
+            Assert.True(File.ReadAllText(Path.Combine(_outPath, "test3_äöå.txt"), System.Text.Encoding.UTF8) == mockFiles[2]);
         }
     }
 }

--- a/Frends.Community.Zip/Definition.cs
+++ b/Frends.Community.Zip/Definition.cs
@@ -11,6 +11,8 @@ namespace Frends.Community.Zip
     public enum SourceFilesType { PathAndFileMask, FileList }
     public enum UseZip64Option { Always, AsNecessary, Never };
 
+    public enum FileEncoding { Default, UTF8, ANSI, ASCII, Unicode, Other }
+
     public class SourceProperties
     {
         /// <summary>
@@ -193,6 +195,20 @@ namespace Frends.Community.Zip
         /// </summary>
         [DefaultValue(true)]
         public bool RenameDuplicateFiles { get; set; }
+
+        /// <summary>
+        /// Encoding for the written content. By selecting 'Other' you can use any encoding.
+        /// </summary>
+        public FileEncoding FileEncoding { get; set; }
+
+        [UIHint(nameof(FileEncoding), "", FileEncoding.Default)]
+        public bool EnableBom { get; set; }
+
+        /// <summary>
+        /// File encoding to be used. A partial list of possible encodings: https://en.wikipedia.org/wiki/Windows_code_page#List
+        /// </summary>
+        [UIHint(nameof(FileEncoding), "", FileEncoding.Other)]
+        public string EncodingInString { get; set; }
     }
 
     public class MemoryOutput

--- a/Frends.Community.Zip/Definition.cs
+++ b/Frends.Community.Zip/Definition.cs
@@ -11,7 +11,7 @@ namespace Frends.Community.Zip
     public enum SourceFilesType { PathAndFileMask, FileList }
     public enum UseZip64Option { Always, AsNecessary, Never };
 
-    public enum FileEncoding { Default, UTF8, ANSI, ASCII, Unicode, Other }
+    public enum Encoding { Default, UTF8, ANSI, ASCII, Unicode, Other }
 
     public class SourceProperties
     {
@@ -197,17 +197,17 @@ namespace Frends.Community.Zip
         public bool RenameDuplicateFiles { get; set; }
 
         /// <summary>
-        /// Encoding for the written content. By selecting 'Other' you can use any encoding.
+        /// Encoding for the zip metadata. By selecting 'Other' you can use any encoding.
         /// </summary>
-        public FileEncoding FileEncoding { get; set; }
+        public Encoding Encoding { get; set; }
 
-        [UIHint(nameof(FileEncoding), "", FileEncoding.Default)]
+        [UIHint(nameof(Encoding), "", Encoding.Default)]
         public bool EnableBom { get; set; }
 
         /// <summary>
-        /// File encoding to be used. A partial list of possible encodings: https://en.wikipedia.org/wiki/Windows_code_page#List
+        /// Zip metadata encoding to be used. A partial list of possible encodings: https://en.wikipedia.org/wiki/Windows_code_page#List
         /// </summary>
-        [UIHint(nameof(FileEncoding), "", FileEncoding.Other)]
+        [UIHint(nameof(Encoding), "", Encoding.Other)]
         public string EncodingInString { get; set; }
     }
 

--- a/Frends.Community.Zip/ZipTask.cs
+++ b/Frends.Community.Zip/ZipTask.cs
@@ -253,7 +253,7 @@ namespace Frends.Community.Zip
         {
             MemoryStream output = new MemoryStream();
 
-            Encoding encoding = GetEncoding(options.FileEncoding, options.EnableBom, options.EncodingInString);
+            System.Text.Encoding encoding = GetEncoding(options.Encoding, options.EnableBom, options.EncodingInString);
 
             using (ZipFile zip = new ZipFile())
             {
@@ -302,22 +302,22 @@ namespace Frends.Community.Zip
             return new MemoryOutput { ResultBytes = output.ToArray() };
         }
 
-        private static Encoding GetEncoding(FileEncoding optionsFileEncoding, bool optionsEnableBom, string optionsEncodingInString)
+        private static System.Text.Encoding GetEncoding(Encoding optionsFileEncoding, bool optionsEnableBom, string optionsEncodingInString)
         {
             switch (optionsFileEncoding)
             {
-                case FileEncoding.Default:
+                case Encoding.Default:
                     return null;
-                case FileEncoding.Other:
-                    return Encoding.GetEncoding(optionsEncodingInString);
-                case FileEncoding.ASCII:
-                    return Encoding.ASCII;
-                case FileEncoding.ANSI:
-                    return Encoding.Default;
-                case FileEncoding.UTF8:
+                case Encoding.Other:
+                    return System.Text.Encoding.GetEncoding(optionsEncodingInString);
+                case Encoding.ASCII:
+                    return System.Text.Encoding.ASCII;
+                case Encoding.ANSI:
+                    return System.Text.Encoding.Default;
+                case Encoding.UTF8:
                     return optionsEnableBom ? new UTF8Encoding(true) : new UTF8Encoding(false);
-                case FileEncoding.Unicode:
-                    return Encoding.Unicode;
+                case Encoding.Unicode:
+                    return System.Text.Encoding.Unicode;
                 default:
                     throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
Implemented the requested feature for selecting encoding for filenames and comments (zipfile metadata). Implementation is created for the CreateArchiveInMemory task. 

Default value is "Default", which does not differ from the earlier state where library's default value (IBM437 or unspecified) is used. If a value is selected, it will be used for encoding the metadata.

Fixes #11 